### PR TITLE
Changed group to append

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,7 @@
   ansible.builtin.user:
     name: "{{ microk8s_user }}"
     groups: microk8s
+    append: true
   become: true
 
 - name: "Set ownership of $HOME/.kube caching directory"


### PR DESCRIPTION
In stead of adding the group, all user groups get replaced

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html#parameter-append
